### PR TITLE
Fix TypeError, use memoization and debounce requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babili": "0.0.9",
     "cerebro-tools": "^0.1.0",
     "css-loader": "^0.26.0",
+    "p-debounce": "^1.0.0",
     "react": "^15.4.1",
     "rimraf": "^2.6.1",
     "style-loader": "^0.13.1",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,13 @@ const fetchPackages = (query) => {
 };
 
 const extractQueryFromTerm = (term) => {
-  const [_, query] = term.match(/^npm\s(.+)$/);
+  const match = term.match(/^npm\s(.+)$/);
+
+  if (!match) {
+    return false;
+  }
+
+  const [_, query] = match;
   return query.trim();
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,18 @@
 'use strict';
+const debounce = require('p-debounce');
+const {memoize} = require('cerebro-tools');
 const icon = require('./assets/npm-logo.png');
 const id = 'npm';
+const memoizationSettings = {
+  maxAge: 60 * 1000 // 1 minute
+};
 
-const fetchPackages = (query) => {
+const fetchPackages = debounce(memoize((query) => {
   console.log('query passed:', query)
   return fetch(`https://api.npms.io/v2/search?q=${query}`)
     .then(response => response.json())
     .then(data => data.results);
-};
+}, memoizationSettings), 300);
 
 const extractQueryFromTerm = (term) => {
   const match = term.match(/^npm\s(.+)$/);

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ const fn = (scope) => {
 
   const query = extractQueryFromTerm(term);
 
-  if (query && query.length > 0) {
+  if (query) {
     display({ icon, id: 'npm-loading', title: 'Searching NPM packages ...' });
 
     fetchPackages(query).then(results => {


### PR DESCRIPTION
Your plugin was yielding the following error on my Cerebro DevTools console:

```
Error running plugin cerebro-npm TypeError: Cannot read property 'Symbol(Symbol.iterator)' of null(…)
```

This PR fix it. Both commits have clear explanation on what happened and how I fixed it.